### PR TITLE
Add snippet allowing deactivated membership levels to be renewed

### DIFF
--- a/rcp-renew-deactivated-levels.php
+++ b/rcp-renew-deactivated-levels.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Plugin Name: Restrict Content Pro - Renew Deactivated Membership Levels
+ * Description: Allows deactivated membership levels to be renewed by customers with existing memberships.
+ * Version: 1.0
+ * Author: Restrict Content Pro team
+ * License: GPL2
+ */
+
+add_filter( 'rcp_can_renew_deactivated_memberships', '__return_true' );

--- a/rcp-renew-deactivated-levels.php
+++ b/rcp-renew-deactivated-levels.php
@@ -7,4 +7,4 @@
  * License: GPL2
  */
 
-add_filter( 'rcp_can_renew_deactivated_memberships', '__return_true' );
+add_filter( 'rcp_can_renew_deactivated_membership_levels', '__return_true' );


### PR DESCRIPTION
By default, if a membership level is deactivated it cannot be renewed. `3.1` is adding a filter to control this functionality, and this snippet will allow deactivated membership levels to be renewed by customers with existing memberships. New signups are still not allowed, but existing members can renew those memberships.