### PR TITLE
Add 2-day grace period to expiration date value.

### DIFF
--- a/rcp-add-expiration-grace-period.php
+++ b/rcp-add-expiration-grace-period.php
@@ -22,4 +22,35 @@ function ag_rcp_add_expiration_cron_grace_period( $query_args ) {
 	return $query_args;
 
 }
+
 add_filter( 'rcp_check_for_expired_memberships_query_args', 'ag_rcp_add_expiration_cron_grace_period' );
+
+/**
+ * Adds a 2-day grace period to the expiration date value.
+ *
+ * @param string         $expiration_date
+ * @param bool           $formatted
+ * @param int            $membership_id
+ * @param RCP_Membership $membership
+ *
+ * @return string
+ */
+function ag_rcp_add_expiration_date_grace( $expiration_date, $formatted, $membership_id, $membership ) {
+
+	// Bail if never expires or formatted.
+	if ( 'none' === $expiration_date || empty( $expiration_date ) || $formatted ) {
+		return $expiration_date;
+	}
+
+	try {
+		$expiration = new DateTime( $expiration_date );
+		$expiration->modify( '+2 days' );
+
+		return $expiration->format( 'Y-m-d H:i:s' );
+	} catch ( \Exception $e ) {
+		return $expiration_date;
+	}
+
+}
+
+add_filter( 'rcp_membership_get_expiration_date', 'ag_rcp_add_expiration_date_grace', 10, 4 );


### PR DESCRIPTION
Haven't tested this yet... but the goal is to filter the expiration date itself to add a 2-day grace period there. This prevents RCP from auto expiring outside the cron job via the fallback method until the 2-day grace has elapsed.