### PR TITLE
Update UM query args so meta_query is not overwritten.

### DIFF
--- a/integrations/ultimate-member/rcp-member-directory.php
+++ b/integrations/ultimate-member/rcp-member-directory.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Restrict Content Pro - Ultimate Member Directory
  * Description: Adds support for displaying active RCP members in the member directories for Ultimate Member.
- * Version: 1.0
+ * Version: 1.0.1
  * Author: Sandhills Development, LLC
  * Author URI: https://sandhillsdev.com
  * License: GPL2

--- a/integrations/ultimate-member/rcp-member-directory.php
+++ b/integrations/ultimate-member/rcp-member-directory.php
@@ -107,16 +107,14 @@ function jp_um_prepare_user_query_args( $query_args, $args ) {
 		return $query_args;
 	}
 
-	$query_args['meta_query'] = array(
-		'relation' => 'AND',
-		array(
-			'key'   => 'rcp_subscription_level',
-			'value' => absint( $level )
-		),
-		array(
-			'key'   => 'rcp_status',
-			'value' => 'active'
-		)
+	$query_args['meta_query']['relation'] = 'AND';
+	$query_args['meta_query'][] = array(
+		'key'   => 'rcp_subscription_level',
+		'value' => absint( $level )
+	);
+	$query_args['meta_query'][] = array(
+		'key'   => 'rcp_status',
+		'value' => 'active'
 	);
 
 	// Remove the UM filters since we're just showing active RCP members.


### PR DESCRIPTION
This updates our query arguments so that we _append_ to `meta_query` instead of overwriting it.