### PR TITLE
Stripe - Disable the "Autofill Link" button

### DIFF
--- a/gateways/rcp-stripe-autofilLink.php
+++ b/gateways/rcp-stripe-autofilLink.php
@@ -1,0 +1,10 @@
+<?php
+/* Disable the "Autofill Link" button Stripe has started adding to the credit card field */
+
+add_filter('rcp_stripe_scripts', function($localize) {
+    if (null == $localize['elementsConfig']) {
+        $localize['elementsConfig'] = [];
+    }
+    $localize['elementsConfig']['disableLink'] = true;
+    return $localize;
+}, 10, 1);


### PR DESCRIPTION
Disables the "Autofill Link" button Stripe has started adding to the credit card field.

**Before:**

![image](https://github.com/restrictcontentpro/library/assets/1409191/01c2a065-5f50-4e78-9af8-8d17c16fe0db)

**After:**

![image](https://github.com/restrictcontentpro/library/assets/1409191/4e219847-dda9-4bb2-a3a5-a38fb8502583)
